### PR TITLE
Add ForgotPassword and ResetPassword endpoints

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,6 +64,10 @@ jobs:
     - name: Autobuild
       uses: github/codeql-action/autobuild@v2
 
+    # Run MSTests to validate the implementations
+    - name: Run MSTests
+        run: dotnet test
+
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -66,7 +66,7 @@ jobs:
 
     # Run MSTests to validate the implementations
     - name: Run MSTests
-        run: dotnet test
+      run: dotnet test
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun

--- a/.github/workflows/deploy-on-release.yml
+++ b/.github/workflows/deploy-on-release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build the Docker image
         run: |
           TAG=${GITHUB_REF#refs/tags/}
-          docker build . --file Dockerfile --tag ${{ secrets.DOCKER_HUB_USERNAME }}/auth-microservice:${TAG} --tag ${{ secrets.DOCKER_HUB_USERNAME }}/auth-microservice:latest
+          docker build . --file Dockerfile --tag ${{ secrets.DOCKER_HUB_USERNAME }}/auth-microservice:${TAG} --tag ${{ secrets.DOCKER_HUB_USERNAME }}/auth-microservice:latest --build-arg SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }}
 
       - name: Push the Docker image
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,10 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build-env
 WORKDIR /app
 
+# Set an environment variable
+ARG SMTP_PASSWORD
+ENV SMTP_PASSWORD=$SMTP_PASSWORD
+
 # Copy csproj and restore as distinct layers
 COPY Auth.MicroService.sln .
 COPY src/Auth.MicroService.WebApi/*.csproj ./src/Auth.MicroService.WebApi/

--- a/src/Auth.MicroService.Application/Auth.MicroService.Application.csproj
+++ b/src/Auth.MicroService.Application/Auth.MicroService.Application.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="MailKit" Version="4.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="8.0.0" />
   </ItemGroup>

--- a/src/Auth.MicroService.Application/JwtUtils/IJwtProvider.cs
+++ b/src/Auth.MicroService.Application/JwtUtils/IJwtProvider.cs
@@ -6,7 +6,9 @@ namespace Auth.MicroService.Application.JwtUtils
     public interface IJwtProvider
     {
         string GenerateJwt(User user);
+        string GeneratePasswordResetToken(User user);
         bool ValidateToken(string token);
+        string ValidatePasswordResetToken(string token);
         int? GetUserIdFromToken(string token);
         Role? GetUserRoleFromToken(string token);
     }

--- a/src/Auth.MicroService.Application/Models/ResetPasswordModel.cs
+++ b/src/Auth.MicroService.Application/Models/ResetPasswordModel.cs
@@ -1,0 +1,9 @@
+namespace Auth.MicroService.Application.Models
+{
+    public class ResetPasswordModel
+    {
+        public string Token { get; set; }
+
+        public string NewPassword { get; set; }
+    }
+}

--- a/src/Auth.MicroService.Application/Models/UpdateUserModel.cs
+++ b/src/Auth.MicroService.Application/Models/UpdateUserModel.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Auth.MicroService.Application.Models
 {
     public class UpdateUserModel

--- a/src/Auth.MicroService.Application/Services/AuthService.cs
+++ b/src/Auth.MicroService.Application/Services/AuthService.cs
@@ -96,6 +96,11 @@ namespace Auth.MicroService.Application.Services
         /// <inheritdoc/>
         public async Task<string> GeneratePasswordResetToken(string email, CancellationToken ct)
         {
+            if (email is null)
+            {
+                throw new ArgumentNullException(nameof(email));
+            }
+
             var user = await _userRepository.GetUserByEmail(email, ct);
             if (user is null)
             {
@@ -108,6 +113,11 @@ namespace Auth.MicroService.Application.Services
 
         public async Task<string> ResetPassword(ResetPasswordModel model, CancellationToken ct)
         {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+            
             var email = _jwtProvider.ValidatePasswordResetToken(model.Token);
             if (email is null)
             {

--- a/src/Auth.MicroService.Application/Services/AuthService.cs
+++ b/src/Auth.MicroService.Application/Services/AuthService.cs
@@ -4,6 +4,7 @@ using Auth.MicroService.Application.Services.Interfaces;
 using Auth.MicroService.Domain.Entities;
 using Auth.MicroService.Domain.Repositories;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,15 +19,18 @@ namespace Auth.MicroService.Application.Services
         private readonly IPasswordHasher<User> _passwordHasher;
         private readonly IUserRepository _userRepository;
         private readonly IJwtProvider _jwtProvider;
+        private readonly IMemoryCache _cache;
 
         public AuthService(
             IUserRepository userRepository,
             IPasswordHasher<User> passwordHasher,
-            IJwtProvider jwtProvider)
+            IJwtProvider jwtProvider,
+            IMemoryCache cache)
         {
             _userRepository = userRepository;
             _passwordHasher = passwordHasher;
             _jwtProvider = jwtProvider;
+            _cache = cache;
         }
 
         /// <inheritdoc/>
@@ -75,6 +79,7 @@ namespace Auth.MicroService.Application.Services
             var passwordResult = _passwordHasher.VerifyHashedPassword(user, user.Password, model.Password);
             if (passwordResult != PasswordVerificationResult.Success)
             {
+                IncrementFailedLoginAttempt(model.Email);
                 throw new UnauthorizedAccessException("Invalid login attempt.");
             }
 
@@ -84,7 +89,49 @@ namespace Auth.MicroService.Application.Services
             }
 
             var token = _jwtProvider.GenerateJwt(user);
+            ResetFailedLoginAttempt(model.Email);
             return token;
+        }
+
+        /// <inheritdoc/>
+        public async Task<string> GeneratePasswordResetToken(string email, CancellationToken ct)
+        {
+            var user = await _userRepository.GetUserByEmail(email, ct);
+            if (user is null)
+            {
+                throw new UnauthorizedAccessException("Invalid email.");
+            }
+
+            var token = _jwtProvider.GeneratePasswordResetToken(user);
+            return token;
+        }
+
+        public async Task<string> ResetPassword(ResetPasswordModel model, CancellationToken ct)
+        {
+            var email = _jwtProvider.ValidatePasswordResetToken(model.Token);
+            if (email is null)
+            {
+                throw new UnauthorizedAccessException("Invalid token.");
+            }
+
+            var userByEmail = await _userRepository.GetUserByEmail(email, ct);
+            if (userByEmail is null)
+            {
+                throw new UnauthorizedAccessException("Invalid email.");
+            }
+
+            var user = User.CreateNewUser(
+                userByEmail.UserId,
+                userByEmail.FirstName,
+                userByEmail.LastName,
+                userByEmail.Email,
+                model.NewPassword,
+                userByEmail.BirthDate);
+
+            // Reset the password
+            var userToUpdate = User.SetUserHashedPassword(user, _passwordHasher.HashPassword(user, model.NewPassword));
+            
+            return await _userRepository.UpdateUser(userToUpdate, ct);
         }
 
         /// <inheritdoc/>
@@ -122,5 +169,26 @@ namespace Auth.MicroService.Application.Services
             return newToken;
         }
 
+        private void IncrementFailedLoginAttempt(string email)
+        {
+            var cacheEntry = _cache.GetOrCreate(email, entry =>
+            {
+                entry.SetAbsoluteExpiration(TimeSpan.FromMinutes(5));
+                return new Tuple<int, DateTimeOffset>(0, DateTimeOffset.Now);
+            });
+
+            var updatedCacheEntry = new Tuple<int, DateTimeOffset>(cacheEntry.Item1 + 1, cacheEntry.Item2);
+            _cache.Set(email, updatedCacheEntry, DateTimeOffset.Now.AddMinutes(5));
+
+            if (updatedCacheEntry.Item1 > 3 && DateTimeOffset.Now - updatedCacheEntry.Item2 < TimeSpan.FromMinutes(5))
+            {
+                throw new UnauthorizedAccessException("Too many failed login attempts. Please try again later.");
+            }
+        }
+
+        private void ResetFailedLoginAttempt(string email)
+        {
+            _cache.Remove(email);
+        }
     }
 }

--- a/src/Auth.MicroService.Application/Services/EmailService.cs
+++ b/src/Auth.MicroService.Application/Services/EmailService.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Auth.MicroService.Application.Services.Interfaces;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Configuration;
+using MimeKit;
+
+namespace Auth.MicroService.Application.Services
+{
+
+    public class EmailService : IEmailService
+    {
+        private readonly IConfiguration _configuration;
+
+        public EmailService(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public async Task SendPasswordResetEmail(string email, string token, CancellationToken ct)
+        {
+            var emailMessage = new MimeMessage();
+
+            emailMessage.From.Add(new MailboxAddress(_configuration["Email:Smtp:Username"], _configuration["Email:Smtp:Username"]));
+            emailMessage.To.Add(new MailboxAddress(email, email));
+            emailMessage.Subject = "Auth.MicroService - Password Reset Request";
+            emailMessage.Body = new TextPart("plain") 
+            { 
+                Text = $"Dear user,\n\n" +
+                "You have requested to reset your password. Please make a POST request to the /api/auth/resetPassword endpoint with the following JSON body:\n\n" +
+                "{\n" +
+                $"  \"token\": \"{token}\",\n" +
+                "  \"newPassword\": \"your new password\"\n" +
+                "}\n\n" +
+                "Please replace \"your new password\" with your new password.\n\n" +
+                "If you did not request a password reset, please ignore this email.\n\n" +
+                "Disclaimer: This is a project for a master's degree and is not intended for real use.\n\n" +
+                "Best,\n" +
+                "Auth.MicroService Team"
+            };
+
+            using (var client = new SmtpClient())
+            {
+                await client.ConnectAsync(_configuration["Email:Smtp:Host"], int.Parse(_configuration["Email:Smtp:Port"]), SecureSocketOptions.StartTls);
+                await client.AuthenticateAsync(_configuration["Email:Smtp:Username"], Environment.GetEnvironmentVariable("SMTP_PASSWORD"));
+
+                await client.SendAsync(emailMessage);
+
+                await client.DisconnectAsync(true);
+            }
+        }
+    }
+}

--- a/src/Auth.MicroService.Application/Services/Interfaces/IAuthService.cs
+++ b/src/Auth.MicroService.Application/Services/Interfaces/IAuthService.cs
@@ -26,6 +26,22 @@ namespace Auth.MicroService.Application.Services.Interfaces
         Task<string> UserLogin(LoginModel model, CancellationToken ct);
 
         /// <summary>
+        /// Generates a password reset token.
+        /// </summary>
+        /// <param name="email">The user's email.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<string> GeneratePasswordResetToken(string email, CancellationToken ct);
+
+        /// <summary>
+        /// Resets a user's password.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        Task<string> ResetPassword(ResetPasswordModel model, CancellationToken ct);
+
+        /// <summary>
         /// Validates one token.
         /// </summary>
         /// <param name="token">The token.</param>

--- a/src/Auth.MicroService.Application/Services/Interfaces/IEmailService.cs
+++ b/src/Auth.MicroService.Application/Services/Interfaces/IEmailService.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Auth.MicroService.Application.Services.Interfaces
+{
+    public interface IEmailService
+    {
+        Task SendPasswordResetEmail(string email, string token, CancellationToken ct);
+    }
+}

--- a/src/Auth.MicroService.Application/Services/UsersService.cs
+++ b/src/Auth.MicroService.Application/Services/UsersService.cs
@@ -102,8 +102,7 @@ namespace Auth.MicroService.Application.Services
                 }
             }
 
-            string email = await _userRepository.UpdateUser(updatedUser, ct);
-            return email;
+            return await _userRepository.UpdateUser(updatedUser, ct);
         }
 
         public async Task DeleteUser(int id, string token, CancellationToken ct)

--- a/src/Auth.MicroService.Domain/Entities/User.cs
+++ b/src/Auth.MicroService.Domain/Entities/User.cs
@@ -173,14 +173,16 @@ namespace Auth.MicroService.Domain.Entities
 
         public User Update(
             string firstName,
-            string lastName,  
-            string email,        
+            string lastName,
+            string email,
+            string password,
             Role roleId,
             bool status)
         {
             this.FirstName = firstName;
             this.LastName = lastName;
             this.Email = email;
+            this.Password = password;
             this.RoleId = roleId;
             this.Status = status;
 

--- a/src/Auth.MicroService.Infrastructure/Repositories/UserRepository.cs
+++ b/src/Auth.MicroService.Infrastructure/Repositories/UserRepository.cs
@@ -77,6 +77,7 @@ namespace Auth.MicroService.Infrastructure.Repositories
                 user.FirstName,
                 user.LastName,
                 user.Email,
+                user.Password,
                 user.RoleId,
                 user.Status);
 

--- a/src/Auth.MicroService.WebApi/Controllers/AuthController.cs
+++ b/src/Auth.MicroService.WebApi/Controllers/AuthController.cs
@@ -18,14 +18,18 @@ namespace Auth.MicroService.WebApi.Controllers
     public class AuthController : ControllerBase
     {
         private readonly IAuthService _authService;
+        private readonly IEmailService _emailService;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AuthController"/> class.
         /// </summary>
         /// <param name="authService">The authentication service.</param>
-        public AuthController(IAuthService authService)
+        /// <param name="emailService">The email service.</param>
+        public AuthController(IAuthService authService,
+            IEmailService emailService)
         {
             _authService = authService;
+            _emailService = emailService;
         }
 
         /// <summary>
@@ -90,6 +94,76 @@ namespace Auth.MicroService.WebApi.Controllers
         }
 
         /// <summary>
+        /// Allows the user to request a password reset.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>An <see cref="ActionResult"/> indicating the result of the operation.</returns>
+        [HttpPost("forgotPassword")]
+        public async Task<ActionResult> ForgotPassword(PostForgotPasswordModel model, CancellationToken ct)
+        {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            try
+            {
+                var token = await _authService.GeneratePasswordResetToken(model.Email, ct);
+                await _emailService.SendPasswordResetEmail(model.Email, token, ct);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occurred while processing the password reset request for email '{Email}'.", model.Email);
+                return BadRequest(new ErrorResponseModel
+                {
+                    Error = $"An error occurred while processing the password reset request for email '{model.Email}'.",
+                    Message = ex.Message
+                });
+            }
+
+            Log.Information("Password reset token generated and email sent to '{Email}'.", model.Email);
+
+            return Ok();
+        }
+
+        /// <summary>
+        /// Performs a password reset.
+        /// </summary>
+        /// <param name="model">The model.</param>
+        /// <param name="ct">The cancellation token.</param>
+        /// <returns>An <see cref="ActionResult"/> indicating the result of the operation.</returns>
+        [HttpPost("resetPassword")]
+        public async Task<ActionResult> ResetPassword(PostResetPasswordModel model, CancellationToken ct)
+        {
+            if (model is null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
+            string email;
+
+            try
+            {
+                var resetPasswordModel = UserMapper.PostResetPasswordModelToResetPasswordModel(model);
+
+                email = await _authService.ResetPassword(resetPasswordModel, ct);
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "An error occurred while resetting the password.");
+                return BadRequest(new ErrorResponseModel
+                {
+                    Error = "An error occurred while resetting the password.",
+                    Message = ex.Message
+                });
+            }
+
+            Log.Information("Password has been reset successfully for user '{Email}'.", email);
+            return Ok($"Password has been reset successfully for user '{email}'.");
+        }
+
+        /// <summary>
         /// Validates one token.
         /// </summary>
         /// <param name="token">The token.</param>
@@ -110,6 +184,7 @@ namespace Auth.MicroService.WebApi.Controllers
                 return BadRequest(new ErrorResponseModel
                 {
                     Error = $"An error occurred while sending the request.",
+                    Message = "Invalid token"
                 });
             }
         }

--- a/src/Auth.MicroService.WebApi/Mapping/UserMapper.cs
+++ b/src/Auth.MicroService.WebApi/Mapping/UserMapper.cs
@@ -11,5 +11,6 @@ namespace Auth.MicroService.WebApi.Mapping
         public static partial LoginModel PostLoginModelToLoginModel(PostLoginModel model);
         public static partial ApproveUserModel PostApproveUserModelToApproveUserModel(PostApproveUserModel model);
         public static partial UpdateUserModel PatchUpdateUserModelToUpdateUserModel(PatchUpdateUserModel model);
+        public static partial ResetPasswordModel PostResetPasswordModelToResetPasswordModel(PostResetPasswordModel model);
     }
 }

--- a/src/Auth.MicroService.WebApi/Models/PostForgotPasswordModel.cs
+++ b/src/Auth.MicroService.WebApi/Models/PostForgotPasswordModel.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Auth.MicroService.WebApi.Models
+{
+    public class PostForgotPasswordModel
+    {
+        [JsonRequired]
+        public string Email { get; init; }
+    }
+}

--- a/src/Auth.MicroService.WebApi/Models/PostLoginModel.cs
+++ b/src/Auth.MicroService.WebApi/Models/PostLoginModel.cs
@@ -9,6 +9,5 @@ namespace Auth.MicroService.WebApi.Models
 
         [JsonRequired]
         public string Password { get; init; }
-
     }
 }

--- a/src/Auth.MicroService.WebApi/Models/PostResetPasswordModel.cs
+++ b/src/Auth.MicroService.WebApi/Models/PostResetPasswordModel.cs
@@ -1,0 +1,13 @@
+using System.Text.Json.Serialization;
+
+namespace Auth.MicroService.WebApi.Models
+{
+    public class PostResetPasswordModel
+    {
+        [JsonRequired]
+        public string Token { get; set; }
+
+        [JsonRequired]
+        public string NewPassword { get; set; }
+    }
+}

--- a/src/Auth.MicroService.WebApi/Program.cs
+++ b/src/Auth.MicroService.WebApi/Program.cs
@@ -61,6 +61,7 @@ namespace Auth.MicroService.WebApi
                     };
                 });
 
+            builder.Services.AddMemoryCache();
             builder.Services.AddAuthorization();
 
             builder.Services.AddControllers();
@@ -69,10 +70,11 @@ namespace Auth.MicroService.WebApi
 
             builder.Services.AddScoped<IAuthService, AuthService>();
             builder.Services.AddScoped<IUsersService, UsersService>();
+            builder.Services.AddScoped<IEmailService, EmailService>();
             builder.Services.AddScoped<IUserRepository, UserRepository>();
             builder.Services.AddScoped<IPasswordHasher<User>, PasswordHasher<User>>();
             builder.Services.AddSingleton<IJwtProvider, JwtProvider>();
-
+            
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddSwaggerGen();

--- a/src/Auth.MicroService.WebApi/appsettings.json
+++ b/src/Auth.MicroService.WebApi/appsettings.json
@@ -1,4 +1,12 @@
 {
+  "Email": {
+    "Smtp": {
+      "Host": "smtp-mail.outlook.com",
+      "Port": "587",
+      "EnableSsl": "true",
+      "Username": "carin_development@outlook.com"
+    }
+  },
   "Elasticsearch": {
     "Url": "http://localhost:9200"
   },

--- a/test/Auth.MicroService.Application.UnitTests/Tests/AuthServiceTests.cs
+++ b/test/Auth.MicroService.Application.UnitTests/Tests/AuthServiceTests.cs
@@ -5,6 +5,7 @@ using Auth.MicroService.Domain.Entities;
 using Auth.MicroService.Domain.Enums;
 using Auth.MicroService.Domain.Repositories;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System;
@@ -19,6 +20,7 @@ namespace Auth.MicroService.Application.UnitTests.Tests
         private Mock<IUserRepository> _userRepositoryMock;
         private Mock<IPasswordHasher<User>> _passwordHasherMock;
         private Mock<IJwtProvider> _jwtProviderMock;
+        private Mock<IMemoryCache> _cacheMock;
         private AuthService _authService;
 
         [TestInitialize]
@@ -27,7 +29,12 @@ namespace Auth.MicroService.Application.UnitTests.Tests
             _userRepositoryMock = new Mock<IUserRepository>();
             _passwordHasherMock = new Mock<IPasswordHasher<User>>();
             _jwtProviderMock = new Mock<IJwtProvider>();
-            _authService = new AuthService(_userRepositoryMock.Object, _passwordHasherMock.Object, _jwtProviderMock.Object);
+            _cacheMock = new Mock<IMemoryCache>();
+            _authService = new AuthService(
+                _userRepositoryMock.Object,
+                _passwordHasherMock.Object,
+                _jwtProviderMock.Object,
+                _cacheMock.Object);
         }
 
         [TestMethod]


### PR DESCRIPTION
Actions:
- Added MemoryCache for user's invalid login attempts and block when it reaches more than 3 (5 minutes);
- Added `EmailService.cs` that sends an email for password resets;
- Added both `forgotPassword` and `resetPassword` endpoints, the first generates a JWT token for password resetting on the second one;
- Update Dockerfile and workflow;
- Add testing step on `codeql.yml`.
